### PR TITLE
Add a method 'topic_label_dict' on the LLDA model to allow retrieving labels

### DIFF
--- a/ext/tomoto/llda.cpp
+++ b/ext/tomoto/llda.cpp
@@ -29,5 +29,18 @@ void init_llda(Rice::Module& m) {
       "topics_per_label",
       [](tomoto::ILLDAModel& self) {
         return self.getNumTopicsPerLabel();
+      })
+    .define_method(
+      "topic_label_dict",
+      [](tomoto::ILLDAModel& self) {
+        auto dict = self.getTopicLabelDict();
+        Array res;
+        auto utf8 = Rice::Class(rb_cEncoding).call("const_get", "UTF_8");
+        for (size_t i = 0; i < dict.size(); i++) {
+          VALUE value = Rice::detail::To_Ruby<std::string>().convert(dict.toWord(i));
+          Object obj(value);
+          res.push(obj.call("force_encoding", utf8));
+        }
+        return res;
       });
 }

--- a/test/llda_test.rb
+++ b/test/llda_test.rb
@@ -7,6 +7,9 @@ class LLDATest < Minitest::Test
     assert_elements_in_delta [0.1], model.alpha
 
     model.add_doc(["new", "document"], labels: ["spam"])
+    model.add_doc(["cuban", "sandwiches"], labels: ["ham"])
     assert model.summary
+
+    assert model.topic_label_dict == ["spam", "ham"]
   end
 end


### PR DESCRIPTION
Thank you for this library, and all of the other excellent ruby libraries you've made!

This adds support for the [LLDAModel.topic_label_dict](https://bab2min.github.io/tomotopy/v0.9.0/en/#tomotopy.LLDAModel.topic_label_dict) method.

I was working with the LLDA model, and I wanted to convert the result from `infer` back into the text labels, so I took a stab at it.  I don't know C++, so I based it off of the `used_vocabs` method in `lda.cpp`

