### PR TITLE
LDA model - allow running infer() on trained models loaded from disk

### DIFF
--- a/lib/tomoto/lda.rb
+++ b/lib/tomoto/lda.rb
@@ -24,7 +24,7 @@ module Tomoto
 
     # TODO support multiple docs
     def infer(doc, iter: 100, tolerance: -1, workers: 0, parallel: :default, together: 0)
-      raise "cannot infer with untrained model" unless defined?(@prepared)
+      raise "cannot infer with untrained model" unless global_step.positive?
       _infer(doc, iter, tolerance, workers, to_ps(parallel), together)
     end
 


### PR DESCRIPTION
I noticed that when saving a trained model, if you load it again and try to call `model.infer(...)` it would error with `cannot infer with untrained model`

Script to reproduce:
```ruby
model = Tomoto::LDA.new(k: 2, seed: 42)
model.add_doc(["this", "is", "a", "test"])
model.train
model.save("model.bin")
model.infer(model.make_doc("test"))
=> [[0.3719014823436737, 0.6280985474586487], -1.396169662475586]

model = Tomoto::LDA.load("model.bin")
model.infer(model.make_doc("test"))
=> Traceback (most recent call last):
=> ./tomoto-ruby/lib/tomoto/lda.rb:27:in `infer': cannot infer with untrained model (RuntimeError)
```

This changes the infer method to look at the [LDAModel.global_step](https://bab2min.github.io/tomotopy/v/en/#tomotopy.LDAModel.global_step), which is a count of the number of rounds of training.

One note on this change:
It doesn't cause the `rm_top`, `min_df`, or `min_cf` variables to be set, I didn't see a way to get them out of the loaded model.